### PR TITLE
Add support for initial dry-runs

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+
 - name: Restart Redis Server
   become: yes
   ansible.builtin.service:
     name: "{{ redis_server_service_name }}"
     state: restarted
     daemon_reload: yes
+  when: not is_initial_dryrun
 
 - name: Restart Redis Sentinel
   become: yes
@@ -17,5 +19,6 @@
     name: "{{ redis_sentinel_service_name }}"
     state: restarted
     daemon_reload: yes
+  when: not is_initial_dryrun
 
 ...

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,5 +29,19 @@ provisioner:
     converge: converge.yml
 verifier:
   name: ansible
+scenario:
+  name: default
+  test_sequence:
+    - destroy
+    - lint
+    - syntax
+    - create
+    - prepare
+    - check
+    - converge
+    - idempotence
+    - check
+    - verify
+    - destroy
 
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+
 - name: Check whether Redis server is installed.
   ansible.builtin.stat:
     path: "{{ redis_bin }}"
   register: redis_server_installed
+
+- name: Determine initial dry-run.
+  ansible.builtin.set_fact:
+    is_initial_dryrun: "{{ ansible_check_mode and not redis_server_installed.stat.exists }}"
 
 - name: Check Redis version.
   ansible.builtin.command:
@@ -72,12 +77,14 @@
       become: yes
       community.general.make:
         chdir: "{{ redis_build_dir }}"
+      when: not is_initial_dryrun
 
     - name: Install Redis.
       become: yes
       community.general.make:
         chdir: "{{ redis_build_dir }}"
         target: install
+      when: not is_initial_dryrun
       notify:
         - Restart Redis Server
         - Restart Redis Sentinel
@@ -169,6 +176,7 @@
     state: started
     enabled: yes
     daemon_reload: yes
+  when: not is_initial_dryrun
   notify: Restart Redis Server
 
 - name: Register Redis Sentinel Service.
@@ -178,6 +186,7 @@
     state: started
     enabled: yes
     daemon_reload: yes
+  when: not is_initial_dryrun
   notify: Restart Redis Sentinel
 
 ...


### PR DESCRIPTION
* The role will fail in initial dry-runs if package build-essential is not installed on instance, hence adding support for initial dry-runs.