### PR TITLE
Add folder molecule to command ansible-lint in molecule lint

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ platforms:
     override_command: false
 lint: |
   yamllint --strict --format colored . &&
-  ansible-lint -v --force-color --offline --exclude .pipenv/ .
+  ansible-lint -v --force-color --offline --exclude .pipenv/ . molecule/
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
* Folder molecule needs to be linted as well. So far it is not included, hence add it to command ansible-lint in linting step of molecule.